### PR TITLE
fixed svg loader in storybook's webpack

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -2,10 +2,25 @@ const path = require('path');
 const SRC_PATH = path.join(__dirname, '../src');
 const STORIES_PATH = path.join(__dirname, '../stories');
 
-//dont need stories path if you have your stories inside your src folder
 module.exports = ({ config }) => {
+  // don't use storybook's default svg configuration
+  // https://github.com/storybookjs/storybook/issues/6758
+  config.module.rules = config.module.rules.map(rule => {
+    if (rule.test.toString().includes('svg')) {
+      const test = rule.test
+        .toString()
+        .replace('svg|', '')
+        .replace(/\//g, '');
+      return { ...rule, test: new RegExp(test) };
+    } else {
+      return rule;
+    }
+  });
+
+  // ts rules
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
+    // dont need stories path if you have your stories inside your src folder
     include: [SRC_PATH, STORIES_PATH],
     use: [
       {
@@ -18,5 +33,25 @@ module.exports = ({ config }) => {
     ]
   });
   config.resolve.extensions.push('.ts', '.tsx');
+
+  // svg rules
+  config.module.rules.push({
+    // in css files, svg is loaded as a url formatted string
+    test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+    issuer: { test: /\.css$/ },
+    use: {
+      loader: 'svg-url-loader',
+      options: { encoding: 'none', limit: 10000 }
+    }
+  });
+  config.module.rules.push({
+    // in js, jsx, ts, and tsx files svg is loaded as a raw string
+    test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+    issuer: { test: /\.(js|jsx|ts|tsx)$/, },
+    use: {
+      loader: 'raw-loader'
+    }
+  });
+
   return config;
 };

--- a/src/icons.stories.tsx
+++ b/src/icons.stories.tsx
@@ -12,17 +12,24 @@ import '@jupyterlab/application/style/index.css';
 import '@jupyterlab/theme-light-extension/style/index.css';
 
 const buildIcon = () => ( 
-  <DefaultIconReact name={'build'} />
-)
+  <DefaultIconReact name={'build'} kind={'sideBar'} />
+);
+
+const runningIcon = () => (
+  <DefaultIconReact name={'running'} height={'800px'} width={'800px'} />
+);
 
 const html5Icon = () => (
-  <div className={'foobar'}>
-    <DefaultIconReact name={'html5'} kind={'launcherSection'} center={true} />
+  <div className={'foobar'} style={{height: '500px', width: '500px'}}>
+    <DefaultIconReact name={'html5'} center={true} />
   </div>
 );
 
 storiesOf('Icons', module)
   .add('buildIcon', buildIcon);
+
+storiesOf('Icons', module)
+  .add('runningIcon', runningIcon);
 
 storiesOf('Icons', module)
   .add('html5Icon', html5Icon);


### PR DESCRIPTION
Fixes #1

@echarles The problem you're running into in #1 isn't a pathing issue; rather instead it's that storybook defines a default svg loading rule for its webpack. It's convoluted to do, but you can override said rule and then add your own. This PR makes it so that the svg loader scheme used by storybook here matches that used by jlab core, which fixes the issue with svg icons.